### PR TITLE
ユーザアカウント削除後の再連携などで一意のユーザUUIDが変わった場合に対応

### DIFF
--- a/backend/app/Http/Controllers/Api/StravaAuthController.php
+++ b/backend/app/Http/Controllers/Api/StravaAuthController.php
@@ -64,9 +64,9 @@ class StravaAuthController extends Controller
 
         DB::table('strava_users')
             ->updateOrInsert([
-                'user_uuid'     => $user->uuid,
                 'strava_id'     => $stravaUserToken->athlete->id
             ], [
+                'user_uuid'     => $user->uuid,
                 'expires_at'    => $stravaUserToken->expires_at,
                 'refresh_token' => $stravaUserToken->refresh_token,
                 'access_token'  => $stravaUserToken->access_token,


### PR DESCRIPTION
STRAVA連携済みユーザアカウントの削除後、STRAVAログインを試行した際にSQLエラーによって再登録が不可能な事象。
現在の`user_uuid`で`strava_id AND user_uuid`のupsertをしていたが、この条件下のレコードは存在せずに処理がINSERT側に動いていた。STRAVA APIから取得した`strava_id`(unique)を登録する際、その値と同じである削除前のレコードは存在しているためエラーが発生。
upsert処理時に`user_uuid`での検索を行わず、`strava_id`の一致するカラムが存在する条件ではUPDATEすることで対応。