### PR TITLE
プロフィール画像エンコード時にtmpディレクトリが存在しない場合作成する処理を追加

### DIFF
--- a/backend/app/Models/UserProfile.php
+++ b/backend/app/Models/UserProfile.php
@@ -46,7 +46,19 @@ class UserProfile extends Model
     public function encodeImage(object $original_img)
     {
         $uuid = (string)Str::uuid();
-        $path = "img/tmp/{$uuid}.jpg"; // 書き出し後の画像の一時パス
+        $tmp_directory = 'img/tmp';
+
+        if(!file_exists($tmp_directory)){
+            // ディレクトリが存在しない場合は作成
+            mkdir(
+                $tmp_directory,
+                $permissions = 0777,
+                $recursive = false,
+                $context = null
+            );
+        }
+
+        $path = "{$tmp_directory}/{$uuid}.jpg"; // 書き出し後の画像の一時パス
 
         $img = Image::make($original_img)
             ->encode('jpg');


### PR DESCRIPTION
Gitでは空のディレクトリを共有することができないため、クローン時にディレクトリを手動で作成する必要があった。この手順が抜けることによるエラーを防止するため、ディレクトリが存在しない場合は作成されるよう処理を追加 