### PR TITLE
ログイン時のパスワードバリデーションを正規表現からstring型に変更

### DIFF
--- a/backend/app/Http/Requests/LoginRequest.php
+++ b/backend/app/Http/Requests/LoginRequest.php
@@ -25,7 +25,7 @@ class LoginRequest extends FormRequest
     {
         return [
             'email'=>'required|email|max:255',
-            'password'=>'required|regex:/^[0-9a-zA-Z]+$/|min:6|max:64',
+            'password'=>'required|string|min:6|max:64',
             'remember'=>'boolean',
         ];
     }


### PR DESCRIPTION
ログイン時のパスワードのバリデーション型がパスワード更新フォームのものと一部異なることにより、文字列によっては変更後に正常にログインできない不具合を修正