### PR TITLE
fix : ライド詳細画面のURIパラメータのバリデーションを追加し、不正なSQLの発行を防止

### DIFF
--- a/backend/app/Http/Controllers/RideViewController.php
+++ b/backend/app/Http/Controllers/RideViewController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class RideViewController extends Controller
 {
@@ -36,6 +37,9 @@ class RideViewController extends Controller
      */
     public function showRide(Request $request)
     {
+        if(!Str::isUuid($request->uuid)){
+            return abort(404);
+        }
         $ride = DB::table('rides')
             ->where('uuid', $request->uuid)
             ->get('name');


### PR DESCRIPTION
`/ride?uuid={UUID}`時のパラメータが不正な場合にバリデートされずSQL発行時にエラーが発生するためバリデーションを追加