### PR TITLE
プロフィール画像の配信URLをCloudFrontのものに変更

### DIFF
--- a/backend/app/Models/UserProfile.php
+++ b/backend/app/Models/UserProfile.php
@@ -23,7 +23,7 @@ class UserProfile extends Model
     public function putUserImage(string $path)
     {
         $path = Storage::disk('s3')->putFile('img/user_profiles', $path, 'public');
-        return Storage::disk('s3')->url($path);
+        return 'https://image.bipokele.com/'.$path;
     }
 
     /**


### PR DESCRIPTION
画像配信をS3からCloudFront経由に変更したため保存するパスを変更

`s3-ap-northeast-1.amazonaws.com/bipokele-app`  
=>
`image.bipokele.com`  