### PR TITLE
Fix/create ride

### DIFF
--- a/backend/app/Http/Controllers/Api/Ride/RideRouteController.php
+++ b/backend/app/Http/Controllers/Api/Ride/RideRouteController.php
@@ -28,7 +28,7 @@ class RideRouteController extends Controller
      */
     public function createRideRoute(CreateRideRouteRequest $request)
     {
-        if (!is_numeric($request['strava_route_id'])) {
+        if ($request['strava_route_id'] !== null && !is_numeric($request['strava_route_id'])) {
             return response()->json(['status' => false]);
         }
 

--- a/backend/resources/js/createRideForm.js
+++ b/backend/resources/js/createRideForm.js
@@ -600,11 +600,11 @@ new Vue({
                 "save_status":Boolean(this.rr_save_status),
             }
 
-            this.rr_httpErrors = this.createRideValidation.validationRideRoute(data);
-            if(this.rr_httpErrors){
+            const validationResult = this.createRideValidation.validationRideRoute(data)
+            if(validationResult.length){
                 // 入力内容にエラーが存在する場合
+                this.rr_httpErrors = validationResult;
                 this.rr_isPush = false;
-
                 return;
             }
 

--- a/backend/resources/js/createRideForm.js
+++ b/backend/resources/js/createRideForm.js
@@ -632,9 +632,8 @@ new Vue({
                     "lap_status":this.rr_lap_status
                 };
 
-                //
-                this.rideRoutes.data.push(data);
                 this.selectedRideRouteKey = this.rideRoutes.data.length;
+                this.rideRoutes.data.push(data);
 
                 // モーダルのリセット
                 this.resetModals();

--- a/backend/resources/js/validations/createRide.js
+++ b/backend/resources/js/validations/createRide.js
@@ -47,7 +47,7 @@ export default class CreateRideValidation {
         if(!inputData.comment){
             error_arr.push('ルートの説明を入力してください');
         }
-        if(inputData.publish_status == ''){
+        if(inputData.publish_status === ''){
             error_arr.push('公開設定を選択してください');
         }
 

--- a/backend/resources/js/validations/createRide.js
+++ b/backend/resources/js/validations/createRide.js
@@ -47,7 +47,7 @@ export default class CreateRideValidation {
         if(!inputData.comment){
             error_arr.push('ルートの説明を入力してください');
         }
-        if(!inputData.publish_status){
+        if(inputData.publish_status == ''){
             error_arr.push('公開設定を選択してください');
         }
 


### PR DESCRIPTION
- `/create-ride`で生じていたバグの修正
  - フロント側のバリデーション処理を修正
  - `strava_id`が存在しない場合にphp側で早期リターンされる不具合を修正
  - `ride_route`作成成功後にプルダウンで作成したものが選択されない不具合を修正